### PR TITLE
Load Google auth settings via configuration

### DIFF
--- a/Logic/UserLogic.cs
+++ b/Logic/UserLogic.cs
@@ -12,16 +12,22 @@ using System.Linq;
 using Google.Apis.Util.Store;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Configuration;
 
 namespace Logic
 {
     public class UserLogic : BaseLogic, ICRUD<User, int>
     {
-        public UserLogic() { }
+        private readonly string clientId;
+        private readonly string clientSecret;
+        private readonly string redirectUri;
 
-        private readonly string clientId = "786922175766-loef3sj7qqqo008nmrb8btqbhgijnghm.apps.googleusercontent.com";
-        private readonly string clientSecret = "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";
-        private readonly string redirectUri = "TU_REDIRECT_URI";
+        public UserLogic()
+        {
+            clientId = ConfigurationManager.AppSettings["GoogleClientId"];
+            clientSecret = ConfigurationManager.AppSettings["GoogleClientSecret"];
+            redirectUri = ConfigurationManager.AppSettings["GoogleRedirectUri"];
+        }
 
         public async Task<User> AuthenticateWithGoogle(string code)
         {

--- a/WebAPI/Web.config
+++ b/WebAPI/Web.config
@@ -9,6 +9,9 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="GoogleClientId" value="YOUR_CLIENT_ID" />
+    <add key="GoogleClientSecret" value="YOUR_CLIENT_SECRET" />
+    <add key="GoogleRedirectUri" value="YOUR_REDIRECT_URI" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.8" />


### PR DESCRIPTION
## Summary
- pull Google OAuth keys from `appSettings`
- add placeholders for the OAuth keys in Web.config

## Testing
- `dotnet build FunkoPop-WebAPI.sln` *(fails: command not found)*
- `msbuild FunkoPop-WebAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2affa6308324877616f6802b0639