### PR TITLE
Make connection string configurable

### DIFF
--- a/Data/App.config
+++ b/Data/App.config
@@ -10,6 +10,6 @@
     </providers>
   </entityFramework>
   <connectionStrings>
-    <add name="FunkoPopContext" connectionString="data source=FRANCO-PC\SQLEXPRESS;initial catalog=funkopop;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+    <add name="FunkoPopContext" connectionString="Data Source=(local);Initial Catalog=funkopop;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
 </configuration>

--- a/Data/FunkoPopContext.cs
+++ b/Data/FunkoPopContext.cs
@@ -9,8 +9,25 @@ namespace Data
     public partial class FunkoPopContext : DbContext
     {
         public FunkoPopContext()
-            : base("name=FunkoPopContext")
+            : base(GetConnectionString())
         {
+        }
+
+        private static string GetConnectionString()
+        {
+            var env = Environment.GetEnvironmentVariable("FUNKOPOP_CONNECTION_STRING");
+            if (!string.IsNullOrWhiteSpace(env))
+            {
+                return env;
+            }
+
+            var config = System.Configuration.ConfigurationManager.ConnectionStrings["FunkoPopContext"];
+            if (config != null && !string.IsNullOrWhiteSpace(config.ConnectionString))
+            {
+                return config.ConnectionString;
+            }
+
+            return "Data Source=(local);Initial Catalog=funkopop;Integrated Security=True";
         }
 
         public virtual DbSet<Address> Address { get; set; }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # FunkoPop-WebAPI
+
+## Database Connection
+
+The application uses Entity Framework and expects a connection string named `FunkoPopContext`.
+By default, `Data/App.config` contains a placeholder connection string:
+
+```
+Data Source=(local);Initial Catalog=funkopop;Integrated Security=True
+```
+
+You can override this value by providing a connection string in `Web.config` under
+`<connectionStrings>` or by setting the `FUNKOPOP_CONNECTION_STRING` environment
+variable. When present, the environment variable takes precedence.


### PR DESCRIPTION
## Summary
- replace the connection string in `App.config` with a local placeholder
- allow overriding via an environment variable or `Web.config`
- document the new `FUNKOPOP_CONNECTION_STRING` variable

## Testing
- `dotnet build` *(fails: command not found)*
- `msbuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2b41c2a883248b7c15468f6377f3